### PR TITLE
fix: run npm ci before test in coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,5 +11,6 @@ jobs:
         with:
           node-version: "lts/*"
           registry-url: "https://registry.npmjs.org"
+      - run: npm ci
       - run: npm run test
       - uses: codecov/codecov-action@v3


### PR DESCRIPTION
Coverage upload is failing because I forgot to install packages before running the test script.