### PR TITLE
Bump required version of Node to 18

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,4 +13,4 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm run test
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['18', '20']
+        node-version: ['18', '20', '22']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## requirements
 
-- Node 16+
+- Node 18+
 
 ## usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "typescript-eslint": "^8.7.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "typescript-eslint": "^8.7.0"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "files": [
     "lib/"


### PR DESCRIPTION
Node 16 has been EOL for 1 year now, we can safely bump the minimum version of it in package.json `engines` for future lib versions to 18.

Also, add Node 22 to the test matrix for the future.