### PR TITLE
Expose playerInfo from modern query protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # minestat-es
 
-[![Package Version](https://badge.fury.io/js/minestat-es.svg?)](https://www.npmjs.com/package/minestat-es)
+[![Package Version](https://badge.fury.io/js/minestat-es.svg?2)](https://www.npmjs.com/package/minestat-es)
 [![Code Coverage](https://codecov.io/gh/ayan4m1/minestat-es/branch/main/graph/badge.svg?token=UKTTU7XNAM)](https://codecov.io/gh/ayan4m1/minestat-es)
 
 ## features
@@ -74,12 +74,15 @@ If the server is offline, the object will also contain the properties:
 
 If the server is online, the object will also contain the following properties:
 
-| Key        | Type     | Description                                       |
-| ---------- | -------- | ------------------------------------------------- |
-| version    | `string` | The server's version string                       |
-| motd       | `string` | The server's Message of the Day                   |
-| players    | `number` | The number of players on the server               |
-| maxPlayers | `number` | The maximum number of players the server supports |
+| Key        | Type       | Description                                               |
+| ---------- | ---------- | --------------------------------------------------------- |
+| version    | `string`   | The server's version string                               |
+| motd       | `string`   | The server's Message of the Day                           |
+| players    | `number`   | The number of players on the server                       |
+| maxPlayers | `number`   | The maximum number of players the server supports         |
+| playerInfo | `object[]` | An aray of { id, name } objects for each connected player |
+
+**NOTE**: playerInfo is only populated if the server chooses to do so.
 
 `fetchServerInfo` rejects if an error occurs during SRV record resolution.
 

--- a/src/modernProtocol.test.ts
+++ b/src/modernProtocol.test.ts
@@ -1,10 +1,11 @@
 import { readFileSync } from 'fs';
 
 import { padData } from './index.test';
+import { ModernServerResponse } from './types';
 import { buildMotd, ModernQueryProtocol } from './modernProtocol';
 
 const emptyData = [undefined, Buffer.from([])];
-const validData = [readFileSync('./test/valid.json')];
+const validData = readFileSync('./test/valid.json');
 const invalidData = [
   readFileSync('./test/invalid.json'),
   readFileSync('./test/empty.json')
@@ -22,11 +23,15 @@ describe('ModernQueryProtocol', () => {
     expect(packet.byteLength).toBeGreaterThan(0);
   });
 
-  it.each(validData)('can parse a valid response', (data) => {
-    const { online, error } = protocol.parse(padData(data));
+  it('can parse a valid response', () => {
+    const parsed = JSON.parse(
+      validData.toString('utf-8')
+    ) as unknown as ModernServerResponse;
+    const { online, error, playerInfo } = protocol.parse(padData(validData));
 
     expect(online).toBeTruthy();
     expect(error).toBeFalsy();
+    expect(playerInfo).toEqual(parsed.players.sample);
   });
 
   it.each(emptyData)('can handle an empty buffer', (data) => {

--- a/src/modernProtocol.ts
+++ b/src/modernProtocol.ts
@@ -64,7 +64,8 @@ export class ModernQueryProtocol implements QueryProtocol {
         players: result.players.online,
         maxPlayers: result.players.max,
         version: result.version.name,
-        motd: buildMotd(result.description)
+        motd: buildMotd(result.description),
+        playerInfo: result.players.sample
       };
     } catch (error) {
       return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,10 @@ export type ServerInfo = {
   motd?: string;
   players?: number;
   maxPlayers?: number;
+  playerInfo?: {
+    id: string;
+    name: string;
+  }[];
 };
 
 export type ModernServerResponse = {

--- a/test/valid.json
+++ b/test/valid.json
@@ -1,6 +1,15 @@
 {
   "version": { "protocol": 757, "name": "YourServer 1.12.2-1.21" },
-  "players": { "online": 363, "max": 2000, "sample": [] },
+  "players": {
+    "online": 363,
+    "max": 2000,
+    "sample": [
+      {
+        "id": "123",
+        "name": "TestPlayer"
+      }
+    ]
+  },
   "description": {
     "extra": [
       {


### PR DESCRIPTION
Player info was not being exposed from the ModernQueryProtocol implementation upwards.

 * Pipe object through to response
 * Update docs and test cases